### PR TITLE
change default xml engine

### DIFF
--- a/xlrd2/xlsx.py
+++ b/xlrd2/xlsx.py
@@ -36,9 +36,9 @@ def ensure_elementtree_imported(verbosity, logfile):
         #### 2.7.2.1: fails later with
         #### NotImplementedError: iterparse is not supported on IronPython. (CP #31923)
     else:
-        try: import defusedxml.cElementTree as ET
+        try: import xml.etree.cElementTree as ET
         except ImportError:
-            try: import xml.etree.cElementTree as ET
+            try: import defusedxml.cElementTree as ET
             except ImportError:
                 try: import cElementTree as ET
                 except ImportError:


### PR DESCRIPTION
defusedxml failing on python3 (3.11.6) and defusedxml-0.7.1